### PR TITLE
Add backup-style.css with initial styles

### DIFF
--- a/backup-style.css
+++ b/backup-style.css
@@ -1,0 +1,131 @@
+.page-id-736 #tix table {
+	width: 100%;
+	border-collapse: collapse;
+	background: #fff;
+	border-radius: 10px;
+	overflow: hidden;
+	border: 1px solid #C1CBFF;
+}
+
+.page-id-736 #tix th {
+	background: #fff;
+	color: #000;
+	text-align: left;
+	padding: 1rem;
+	font-size: 1rem;
+}
+.hero-section-heading {
+    padding-top: 60% !important;
+}
+
+img.wp-block-cover__image-background.wp-image-2433.size-large {
+object-position: 90% 100% !important;
+
+}  
+	.hero-section-heading h2 {
+    font-size: 35px !important;	
+}
+	.heading-wordcamp-hero {
+    padding-top: 30px !important;
+}
+	.header-hero-section-logo {
+    width: 30%;
+}
+	
+	.wp-block-navigation_responsive-container.is-nenu-open {
+		padding: 20px !important;
+	}
+	
+	.nav-bar {
+		padding: 20px;
+	}
+	
+#modal-2 {
+      padding-left: 15px;
+      padding-right: 15px;
+      padding-top: 10px;
+      padding-bottom: 10px;
+    }
+	
+	.wp-container-core-group-is-layout-863cc62d.wp-block-group-is-layout-constrained {
+    padding: 0 !important;
+}
+
+.tix-ticket-2589 {
+    border: 1px solid #ffc383;
+}
+
+.tix-ticket-1372 {
+	border: 1px solid #ffc383; 
+}
+
+.page-id-736 #tix .tix-submit,
+.page-id-736 #tix .tix-order .button,
+.page-id-736 #tix .register-btn,
+.page-id-736 #tix input[type="submit"][value*="Register"],
+.page-id-736 #tix .tix-submit .tix-checkout-button {
+	border: none;
+	border-radius: 6px;
+	padding: .6rem 1.2rem;
+	cursor: pointer;
+	transition: background-color .25s ease, transform .15s ease;
+}
+
+/* .page-id-736 #tix .tix-submit:hover,
+.page-id-736 #tix .tix-order .button:hover,
+.page-id-736 #tix .register-btn:hover,
+.page-id-736 #tix input[type="submit"][value*="Register"]:hover,
+.page-id-736 #tix .tix-submit .tix-checkout-button:hover {
+	background-color: #e6b800;
+	transform: translateY(-2px);
+} */
+.page-id-736 #tix tr:last-child td {
+	border-bottom: none;
+}
+
+.page-id-736 #tix .attendee-form,
+.page-id-736 #tix form {
+	background: #fff;
+	padding: 2rem;
+	border-radius: 20px;
+	border: 1px solid #C1CBFF;
+}
+
+#tix-qty-2589 {
+    padding: 4px 8px;
+    font-size: 14px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background-color: #fff;
+    width: 70px;
+}
+
+.page-id-736 #tix tr:last-child td {
+	padding: 50px 40px; 
+}
+
+#tix-coupon-link {
+	border: 2px solid #FE730E;
+    color: #FE730E;
+    padding: 12px;
+    border-radius: 10px;
+}
+
+
+.page-id-736 #tix .attendee-form .form-row,
+.page-id-736 #tix form .form-row {
+	display: flex;
+	flex-wrap: wrap;
+	margin-bottom: 1rem;
+.about-wordcamp-section .wp-block-image.aligncenter.size-full.is-resized img {
+        width: 380px !important;
+    }
+	
+	.recap-wordcamp-section {
+    padding: 0 !important;
+}
+	.sponsors-section {
+    grid-template-columns: 2fr 2fr;
+    gap: 10px;
+}
+}


### PR DESCRIPTION
This pull request introduces new CSS styles to enhance the appearance and layout of various elements on the WordCamp ticketing and hero sections, specifically for page ID 736. The changes focus on improving table styling, form and button appearance, section spacing, and sponsor grid layout.

**Styling improvements for ticketing and hero sections:**

* Added comprehensive table styling for `.page-id-736 #tix table`, including border, background, and radius enhancements.
* Improved form and button appearance for ticket registration, including border radius, padding, and transitions for interactive elements.
* Updated hero section and heading styles, such as padding, font size, and logo width for a more visually appealing header.

**Layout adjustments for sections and sponsors:**

* Refined padding and layout for navigation bar, modal, recap, and group sections to ensure consistent spacing.
* Modified sponsors section to use a two-column grid with a defined gap for better presentation.